### PR TITLE
fix: home, myPage에서 diary 없을 때 무한로딩

### DIFF
--- a/src/components/DiaryInput.tsx
+++ b/src/components/DiaryInput.tsx
@@ -164,7 +164,6 @@ export interface Diary {
 export function DiaryInput({curDiary, categorys} : {curDiary: Diary|null, categorys: Category[]}) {
     const classifiedContents:Content[][] = classifyByCategoryCode(curDiary?.contents || []);
     const classifiedCategorys:Category[][] = classifyByCategoryCode(categorys);
-    const [waitingEmojiCount, setWaitingEmojiCount] = useState<number>(1);
     const [loading, setLoading] = useState<boolean>(false);
     const [hasInputChange, setHasInputChange] = useState<boolean>(false);
     const [inputValues, setInputValues] = useState<ContentForCreate[]>([]);
@@ -214,10 +213,10 @@ export function DiaryInput({curDiary, categorys} : {curDiary: Diary|null, catego
 
     return(
         <div>
-            {(loading || waitingEmojiCount > 0) && <Loading/>}
+            {loading && <Loading/>}
             <div className="BoxL" style={{paddingBottom: '1vh'}}>
                 <DateBox date={new Date()} needSave={true} clickHandler={onClickSaveBtn}/>
-                {curDiary!==null?<EmojiBox diaryId={curDiary.id} setWaitingEmojiBoxCnt={setWaitingEmojiCount}/>:<></>}
+                {curDiary!==null?<EmojiBox diaryId={curDiary.id}/>:<></>}
             </div>
             <div className = "FlexColumn">
                 {

--- a/src/components/DiaryPreview.tsx
+++ b/src/components/DiaryPreview.tsx
@@ -28,8 +28,7 @@ export interface DiaryPreviewProps{
     member: MemberType,
 }
 
-export function DiaryPreview ({diaryPreviewProps, setWaitingEmojiBoxCnt}
-    : {diaryPreviewProps:DiaryPreviewProps, setWaitingEmojiBoxCnt:React.Dispatch<React.SetStateAction<number>>}){
+export function DiaryPreview ({diaryPreviewProps} : {diaryPreviewProps:DiaryPreviewProps}){
     const navigate = useNavigate();
     const classifiedCategorys:Category[][] = classifyByCategoryCode(diaryPreviewProps.categories);
 
@@ -47,7 +46,7 @@ export function DiaryPreview ({diaryPreviewProps, setWaitingEmojiBoxCnt}
                         );
                     })}
                 </div>
-                <EmojiBox diaryId={diaryPreviewProps.id} setWaitingEmojiBoxCnt={setWaitingEmojiBoxCnt}/>
+                <EmojiBox diaryId={diaryPreviewProps.id}/>
             </div>
     );
 }

--- a/src/components/EmojiBox.tsx
+++ b/src/components/EmojiBox.tsx
@@ -3,6 +3,7 @@ import '../styles/components/Box.css'
 import '../styles/components/ReactionRow.css'
 import { emojiApi } from "../services/api";
 import { useEffect, useState } from 'react';
+import { Loading } from './Loading';
 
 export interface Emoji{
     emoji: string,
@@ -30,25 +31,25 @@ function EmojiElement({count, emojiCode, diaryId, isClicked, onClick}
         );
     }
 
-export function EmojiBox({diaryId, setWaitingEmojiBoxCnt}
-    :{diaryId: number, setWaitingEmojiBoxCnt: React.Dispatch<React.SetStateAction<number>>}){
+export function EmojiBox({diaryId}:{diaryId: number}){
     const [renderCount, setRenderCount] = useState(0);
     const [emojis, setEmojis] = useState<Emoji[]>([]);
     const [myEmoji, setMyEmoji] = useState<string>("NONE");
+    const [loading, setLoading] = useState<boolean>(true);
     useEffect(()=>{
         const fetchEmojis = async () => {
             const {emojiCounts, myEmojiState}:{emojiCounts:Emoji[], myEmojiState:string} = await emojiApi.get(diaryId);
             setEmojis(emojiCounts);
             setMyEmoji(myEmojiState);
-            if(setWaitingEmojiBoxCnt!==null){
-                setWaitingEmojiBoxCnt((prevCount)=>prevCount-1);
-            }
+            setLoading(false);
         }
         fetchEmojis();
-    }, [diaryId, renderCount, setWaitingEmojiBoxCnt]);
+    }, [diaryId, renderCount]);
 
     return (
-        <div className="FlexRow" style={{ marginTop: '1vh' }}>
+        <div>
+            {loading ? <Loading/> : 
+            <div className="FlexRow" style={{ marginTop: '1vh' }}>
             <div style={{ flex: 1 }} />
             <div style={{ flex: 3 }}>
                 <div className="FlexRow" style={{ margin: '0 auto' }}>
@@ -76,6 +77,7 @@ export function EmojiBox({diaryId, setWaitingEmojiBoxCnt}
                 </div>
             </div>
             <div style={{ flex: 1 }} />
+        </div>}
         </div>
     );
 }

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -1,4 +1,4 @@
-import { SetStateAction, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { DiaryPreview, DiaryPreviewProps } from "../components/DiaryPreview";
 import { MainLayout } from "../components/layout/MainLayout";
 import { DiaryApi } from "../services/api/DiaryApi";
@@ -6,24 +6,21 @@ import { Loading } from "../components/Loading";
 
 export function Feed() {
     const [loading, setLoading] = useState<boolean>(true);
-    const [waitingEmojiCount, setWaitingEmojiCount] = useState<number>(0);
     const [diarys, setDiarys] = useState<any>();
     useEffect(() => {
         const fetchDiarys = async () => {
             const diaryApi = new DiaryApi();
             const diarys = await diaryApi.all();
             setDiarys(diarys.reverse());
-            setWaitingEmojiCount(diarys.length);
             setLoading(false);
         }
         fetchDiarys();
     }, []);
     return (
         <MainLayout>
-            {(loading || waitingEmojiCount > 0) && <Loading/>}
-            {!loading &&
+            {loading ? <Loading/> :
                 diarys.map((diary:DiaryPreviewProps) => {
-                    return <DiaryPreview diaryPreviewProps={diary} setWaitingEmojiBoxCnt={setWaitingEmojiCount}/>
+                    return <DiaryPreview diaryPreviewProps={diary}/>
                 })
             }
         </MainLayout>

--- a/src/pages/FeedDetail.tsx
+++ b/src/pages/FeedDetail.tsx
@@ -22,8 +22,6 @@ export interface Content {
 
 export function FeedDetail(){
     const { id } = useParams();
-    const [loading, setLoading] = useState<boolean>(true);
-    const [waitingEmojiCount, setWaitingEmojiCount] = useState<number>(1);
     const [diary, setDiary] = useState<{
         id: number,
         date: number[],
@@ -35,20 +33,18 @@ export function FeedDetail(){
             const diaryApi = new DiaryApi();
             const diary = await diaryApi.getById(Number(id));
             setDiary(diary);
-            setLoading(false);
         }
         fetchDiary();
     }, [id]);
     return(
         <MainLayout>
-            {(loading || waitingEmojiCount > 0) && <Loading/>}
-            {!loading && diary &&
+            {diary === undefined ? <Loading/> :
             <div>
                 <div className="BoxL">
                     <div className="FlexColumn" style={{padding:'3vw'}}>
                         <DateBox date={new Date(diary.date[0], diary.date[1], diary.date[2])} needSave={false}/>
                         <MemberProfile member={diary.member} />
-                        <EmojiBox diaryId={diary.id} setWaitingEmojiBoxCnt={setWaitingEmojiCount}/>
+                        <EmojiBox diaryId={diary.id}/>
                     </div>
                 </div>
                 <DiaryView contents = {diary.contents}/>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -49,11 +49,11 @@ export function Home(){
 
     return (
         <MainLayout>
-            {loading ? <Loading/> : (
+            {loading ? <Loading/> : 
                 <div>
                     <DiaryInput curDiary={diary} categorys={categorys}/>
                 </div>
-            )}
+            }
         </MainLayout>
     );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -18,13 +18,10 @@ export function MyPage(){
     const [diary, setDiary] = useState<any>(null);
     const [member, setMember] = useState<MemberType>();
     const [renderCount, setRenderCount] = useState<number>(0);
-    const [waitingEmojiCount, setWaitingEmojiCount] = useState<number>(1);
-    const [loading, setLoading] = useState<boolean>(true);
     useEffect(() => {
         const fetchUser = async () => {
             const member = await memberApi.parseMemberData();
             setMember(member);
-            setLoading(false);
         }
         fetchUser();
     }, []);
@@ -45,8 +42,7 @@ export function MyPage(){
     const navigate = useNavigate();
     return(
         <MainLayout>
-            {(loading || waitingEmojiCount > 0) && <Loading/>}
-            {!loading && member!==undefined &&
+            {member===undefined ? <Loading/> :
             <div className="FlexColumn">
                 <div className="BoxL">
                     <div className="FlexRow"  onClick={() =>{navigate('/profilePage')}}>
@@ -67,7 +63,7 @@ export function MyPage(){
                 {diary === null ? <div className="BoxL" style={{textAlign: "center"}}> no diary </div> :
                 <div>
                     <div className="BoxL">
-                        <EmojiBox diaryId={diary.id} setWaitingEmojiBoxCnt={setWaitingEmojiCount}/>
+                        <EmojiBox diaryId={diary.id}/>
                     </div>
                     <DiaryView contents={diary.contents}/>
                     <Trash onClick={


### PR DESCRIPTION
waitingEmojiCnt 를 무조건 1로 설정했었는데, 다이어리가 없는 경우 emojiBox가 로딩되지 않아 0으로 변경되지 않고 무한로딩 -> 텍스트 loading은 여러개가 겹쳐보였던 것과 달리 설치한 로딩컴포넌트는 여러개 동시에 띄워도 하나로 뜨기 때문에 cnt 없애고 EmojiBox에서 직접 로딩 띄우는 것으로 간단하게 변경